### PR TITLE
Implement a processing context as a key construct in allowing message transformation and processor flow

### DIFF
--- a/src/assignment-contexts/index.ts
+++ b/src/assignment-contexts/index.ts
@@ -16,7 +16,7 @@ export interface AssignmentContext {
 	commitOffset(newOffset: string | Long, metadata: string | null): Promise<void>,
 	committed(): Promise<OffsetAndMetadata>,
 	isEmpty(): Promise<boolean>,
-	log(): any,
+	log(tags, payload): any,
 	seek(offset: string | Long): void,
 	send(messages: NewMessage | NewMessage[]): Promise<ProducedMessageMetadata[]>,
 	watermarks(): Promise<Watermarks>

--- a/src/assignment-contexts/index.ts
+++ b/src/assignment-contexts/index.ts
@@ -1,4 +1,5 @@
 import Source from '../source'
+import Long from 'long'
 
 interface Assignment {
 	topic: string,
@@ -9,7 +10,16 @@ interface Assignment {
 export interface AssignmentContext {
 	topic: string,
 	partition: number,
-	group: string
+	group: string,
+
+	caughtUp(offset: string | Long): Promise<boolean>,
+	commitOffset(newOffset: string | Long, metadata: string | null): Promise<void>,
+	committed(): Promise<OffsetAndMetadata>,
+	isEmpty(): Promise<boolean>,
+	log(): any,
+	seek(offset: string | Long): void,
+	send(messages: NewMessage | NewMessage[]): Promise<ProducedMessageMetadata[]>,
+	watermarks(): Promise<Watermarks>
 }
 
 export interface OffsetAndMetadata {

--- a/src/assignment-contexts/kafka.ts
+++ b/src/assignment-contexts/kafka.ts
@@ -91,7 +91,7 @@ export default async function createContext ({
         },
 
         /* istanbul ignore next */
-        async log() {},
+        async log(tags, payload) {},
         
         seek(offset) {
             return rawStream.seek(offset)

--- a/src/assignment-contexts/kafka.ts
+++ b/src/assignment-contexts/kafka.ts
@@ -61,7 +61,7 @@ export default async function createContext ({
             return watermarks.high.lt(1) || offsetLong.gte(watermarks.high)
         },
         
-        async commitOffset(newOffset, metadata) {
+        async commitOffset(newOffset, metadata = null) {
             try {
                 newOffset = Long.fromValue(newOffset)
             } catch (parseError) {

--- a/src/assignment-contexts/kafka.ts
+++ b/src/assignment-contexts/kafka.ts
@@ -133,8 +133,13 @@ export default async function createContext ({
         group: assignment.group
     }
 
-    const processingPipeline = await createPipeline(assignmentContext, processors)
+    const [processingPipeline, processedOffsets] = await createPipeline(assignmentContext, processors)
     const processedStream = controlledStream.through(processingPipeline)
+
+    processedOffsets.each((offset) => {
+        // this stream is mostly used for testing, so here we'll just want to make sure it doesn't
+        // become a memory leak by instantly relieving all back-pressure
+    })
 
     return {
         topic: assignment.topic,

--- a/src/assignment-contexts/kafka.ts
+++ b/src/assignment-contexts/kafka.ts
@@ -5,7 +5,7 @@ import Invariant from 'invariant'
 import _groupBy from 'lodash.groupby'
 
 import { TopicPartitionStream, Message } from '../streams'
-import { OffsetAndMetadata, Watermarks, NewMessage, ProducedMessageMetadata } from './index'
+import { AssignmentContext } from './index'
 
 export default async function createContext ({
     assignment,
@@ -46,8 +46,8 @@ export default async function createContext ({
         }
     }
 
-    const processorContext = {
-        async caughtUp(offset: string | Long) : Promise<boolean> {
+    const processorContext: AssignmentContext = {
+        async caughtUp(offset) {
             var offsetLong : Long
             try {
                 offsetLong = Long.fromValue(offset)
@@ -60,7 +60,7 @@ export default async function createContext ({
             return watermarks.high.lt(1) || offsetLong.gte(watermarks.high)
         },
         
-        async commitOffset(newOffset: string | Long, metadata: string | null = null) : Promise<void> {
+        async commitOffset(newOffset, metadata) {
             try {
                 newOffset = Long.fromValue(newOffset)
             } catch (parseError) {
@@ -75,7 +75,7 @@ export default async function createContext ({
             }])
         },
         
-        async committed(): Promise<OffsetAndMetadata> {
+        async committed() {
             const payload = { groupId: assignment.group, topic: assignment.topic }
 
             const partitionOffsets = await admin.fetchOffsets(payload)
@@ -84,7 +84,7 @@ export default async function createContext ({
             return { offset, metadata }
         },
         
-        async isEmpty() : Promise<boolean> {
+        async isEmpty() {
             const watermarks = await fetchWatermarks()
 
             return watermarks.high.subtract(watermarks.low).lte(0)
@@ -93,11 +93,11 @@ export default async function createContext ({
         /* istanbul ignore next */
         async log() {},
         
-        seek(offset: string | Long) : void {
+        seek(offset) {
             return rawStream.seek(offset)
         },
 
-        async send(messages: NewMessage | NewMessage[]): Promise<ProducedMessageMetadata[]> {
+        async send(messages) {
             if (!Array.isArray(messages)) messages = [messages]
             const messagesByTopic = _groupBy(messages, (message) => message.topic)
             const topics = Object.keys(messagesByTopic)
@@ -118,7 +118,7 @@ export default async function createContext ({
             })
         },
         /* istanbul ignore next */
-        async watermarks() : Promise<Watermarks> {
+        async watermarks() {
             const { high, low } = await fetchWatermarks()
             
             return {

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -9,7 +9,7 @@ interface ProcessorSetup {
     (assignment: any) : ProcessorFunction[]
 }
 
-interface ProcessingContext {
+export interface ProcessingContext {
     abandon,
     toString: () => string,
     commit: (metadata: any) => Promise<void>,

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -1,0 +1,33 @@
+import H from 'highland'
+import { AssignmentContext } from './assignment-contexts/index'
+import { Message } from './streams'
+
+interface ProcessorSetup {
+    (assignment: any) : ProcessorFunction
+    (assignment: any) : ProcessorFunction[]
+}
+
+interface ProcessingContext {}
+
+interface ProcessorFunction {
+    (val: any, context: ProcessingContext) : Promise<any>
+    (val: any, context: ProcessingContext) : any
+}
+
+export async function createPipeline(
+    controlledStream: Highland.Stream<Message>,
+    assignmentContext : AssignmentContext, 
+    processors : ProcessorSetup[]
+) : Promise<Highland.Stream<any>> {
+    const processedStream = await processors.reduce(async (s, setupProcessor) => {
+        const stream : Highland.Stream<any> = await s
+        
+        const messageProcessor = await setupProcessor(assignmentContext)
+
+        return stream
+            .map(async (message) => await messageProcessor(message, {}))
+            .flatMap((awaitingProcessing) => H(awaitingProcessing))
+    }, Promise.resolve(controlledStream))
+
+    return processedStream
+}

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -65,6 +65,10 @@ export async function createPipeline(
                 abandon,
                 toString: () => `processor context (o=${offset} p=${partition} t=${topic}, ho=${highWaterOffset})`,
                 commit: (metadata) => assignmentContext.commitOffset(Long.fromValue(offset).add(1), metadata),
+                /* istanbul ignore next */
+                log(tags, payload) {
+                    return assignmentContext.log(tags, payload)
+                },
                 group: () => assignmentContext.group,
                 offset: () => offset,
                 partition: () => partition,

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -1,6 +1,7 @@
 import H from 'highland'
 import { AssignmentContext } from './assignment-contexts/index'
 import { Message } from './streams'
+import Long from 'long'
 
 const abandon = Symbol('abandon')
 
@@ -63,7 +64,7 @@ export async function createPipeline(
             const context = {
                 abandon,
                 toString: () => `processor context (o=${offset} p=${partition} t=${topic}, ho=${highWaterOffset})`,
-                commit: (metadata) => assignmentContext.commitOffset(offset, metadata),
+                commit: (metadata) => assignmentContext.commitOffset(Long.fromValue(offset).add(1), metadata),
                 group: () => assignmentContext.group,
                 offset: () => offset,
                 partition: () => partition,

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -81,9 +81,10 @@ export async function createPipeline(
             }, Promise.resolve(message))
 
             processingMessage.then((result) => {
-                if (result === abandon) return
-                push(null, result)
                 processedOffsets.write(offset)
+                if (result !== abandon) {
+                    push(null, result)
+                }
                 next()
             }, (err) => {
                 push(err)

--- a/test/tests/inject.ts
+++ b/test/tests/inject.ts
@@ -41,7 +41,9 @@ Tap.test('Injected AssignmentContext', async (t) => {
 			t.type(injectedMessage.value, Buffer, 'injected message value is converted to a Buffer')
 			t.deepEqual(JSON.parse(injectedMessage.key.toString()), testMessage.key)
 			t.deepEqual(JSON.parse(injectedMessage.value.toString()), testMessage.value)
-
+			
+			await testInterface.caughtUp()
+			
 			t.ok(processMessage.calledWith(injectedMessage))
 		})
 

--- a/test/tests/inject.ts
+++ b/test/tests/inject.ts
@@ -223,7 +223,14 @@ Tap.test('Injected AssignmentContext', async (t) => {
 		const producedMessages = testInterface.producedMessages
 
 		t.ok(processMessage.calledOnce, 'injects any messages sent to test assignment back into processor')
-		t.deepEqual(testMessages, producedMessages, 'messages can be sent in assignment setup')
+		t.deepEqual(
+			testMessages, 
+			producedMessages.map(({ topic, partition, value }) => ({ 
+				topic, 
+				partition, 
+				value: JSON.parse(value.toString()) 
+			}))
+		, 'messages can be sent in assignment setup')
 	})
 
 	await t.test('assignment.seek', async (t) => {

--- a/test/tests/inject.ts
+++ b/test/tests/inject.ts
@@ -215,7 +215,9 @@ Tap.test('Injected AssignmentContext', async (t) => {
 		]
 
 		const testInterface = await testProcessor(async (assignment) => {
-			await assignment.send(testMessages)
+			const [firstMessage, ...otherMessages] = testMessages
+			await assignment.send(firstMessage)
+			await assignment.send(otherMessages)
 
 			return processMessage
 		})

--- a/test/tests/inject.ts
+++ b/test/tests/inject.ts
@@ -106,6 +106,15 @@ Tap.test('Injected AssignmentContext', async (t) => {
 
 
 		})
+
+		await t.test('can inject error', async () => {
+			const testError = new Error('error-to-test-handling')
+			testInterface.inject(testError)
+
+			t.rejects(async () => {
+				await testInterface.processing
+			}, 'error-to-test-handling', 'injected errors are propagated through the processing pipeline')
+		})
 	})
 
 

--- a/test/tests/processors.ts
+++ b/test/tests/processors.ts
@@ -1,0 +1,130 @@
+import Tap from 'tap'
+import createLocalAssignmentContext from '../../src/assignment-contexts/local'
+import { spy } from 'sinon'
+import { ProcessingContext } from '../../src/processors'
+
+import { secureRandom } from '../helpers'
+
+Tap.test('Processor pipeline', async (t) => {
+    const testAssignment = {
+        topic: 'test-topic',
+        partition: 0,
+        group: 'test-group'
+    }
+
+    async function testProcessor (processors, assignment = testAssignment, initialState = {}) {
+        processors = [].concat(processors) // one or more processors
+        
+        return await createLocalAssignmentContext({
+            assignment,
+            processors: processors.map((processor) => async (assignment) => processor),
+            initialState
+        })
+    }
+
+    await t.test('pipes messages and subsequent results to processors in order', async (t) => {
+        const testMessages = Array(2).fill({}).map(() => ({
+            topic: testAssignment.topic,
+            partition: testAssignment.partition,
+            value: `value-${secureRandom()}`,
+            key: `value-${secureRandom()}`
+        }))
+
+        const processMessageOne = spy(({ key, value }) => {
+            return {
+                key: JSON.parse(key.toString()),
+                value: JSON.parse(value.toString())
+            }
+        })
+
+        const processMessageTwo = spy(({ key, value }) => {
+            return {
+                key: `processed-${key}`,
+                value: `processed-${value}`
+            }
+        })
+
+        const testContext = await testProcessor([
+            processMessageOne,
+            processMessageTwo
+        ])
+
+        const injectedMessages = testMessages.map((msg) => testContext.inject(msg))
+
+        await testContext.caughtUp()
+
+        t.equivalent(
+            testContext.processingResults,
+            testMessages.map(({ key, value }) => ({
+                key: `processed-${key}`,
+                value: `processed-${value}`
+            }))
+        , 'messages can be transformed into results, with results of preceding processors forwarded as input to subsequent processors')
+        
+
+        t.equal(
+            processMessageOne.secondCall.calledAfter(processMessageTwo.firstCall), 
+            true,
+            'processing of messages happens depth-first, with single messages going through entire pipeline before accepting next message'
+        )
+    })
+
+    await t.test('provides a processing context', async (t) => {
+        const testMessage = {
+            topic: testAssignment.topic,
+            partition: testAssignment.partition,
+            value: `value-${secureRandom()}`,
+            key: `value-${secureRandom()}`
+        }
+
+        const testContext = await testProcessor([
+            (message, context: ProcessingContext) => {
+                return {
+                    topic: context.topic(),
+                    partition: context.partition(),
+                    group: context.group(),
+                    offset: context.offset(),
+                    timestamp: context.timestamp()
+                }
+            },
+            (contextDescription, context: ProcessingContext) => {
+                const newDescription = {
+                    topic: context.topic(),
+                    partition: context.partition(),
+                    group: context.group(),
+                    offset: context.offset(),
+                    timestamp: context.timestamp()
+                }
+
+                t.equivalent(contextDescription, newDescription, 'context is the same between processors')
+
+                return newDescription
+            }
+        ])
+
+        const injectedMessage = testContext.inject(testMessage)
+
+        await testContext.caughtUp()
+
+        t.equal(testContext.processingResults.length, 1)
+        t.match(
+            testContext.processingResults[0],
+            {
+                topic: testAssignment.topic,
+                partition: testAssignment.partition,
+                group: testAssignment.group
+            }
+        , 'context contains functions returning the topic, partition, group of the assignment')
+
+        t.match(
+            testContext.processingResults[0],
+            {
+                offset: injectedMessage.offset,
+                timestamp: injectedMessage.timestamp
+            }
+        , 'context contains functions returning the offset and timestamp of the message being consumed')
+
+    })
+
+    await t.test('context.abandon')
+})

--- a/test/tests/task.ts
+++ b/test/tests/task.ts
@@ -97,6 +97,7 @@ Tap.test('Task', async (t) => {
 				value: 'a-test-value'
 			}
 			const injectedMessage = testInterface.inject(testMessage)
+			await testInterface.caughtUp()
 
 			t.ok(messageProcessor.calledOnce)
 			t.ok(messageProcessor.calledWith(injectedMessage))


### PR DESCRIPTION
To create an effective processing pipeline, we'll want to be able to do things like abandoning messages (filter), keeping track of the original message even if the results are aggregations, generating more than one result, etc. To allow for this, each processor function will be passed a `ProcessorContext`, allowing for these operations to happen correctly while keeping processing functions stateless and easy to compose.